### PR TITLE
Feat: enhance refresh

### DIFF
--- a/app/core/auth/guards/require-auth-session.server.ts
+++ b/app/core/auth/guards/require-auth-session.server.ts
@@ -1,6 +1,4 @@
-import { redirect } from "@remix-run/node";
-
-import { isGet, makeRedirectToFromHere } from "~/core/utils/http.server";
+import { isGet } from "~/core/utils/http.server";
 
 import { refreshAuthSession } from "../mutations/refresh-auth-session.server";
 import { getAuthAccountByAccessToken } from "../queries/get-auth-account.server";
@@ -42,7 +40,8 @@ export async function requireAuthSession(
 
   // damn, access token expires but we can redirect. Let's go!
   if (!isValidSession && isGet(request)) {
-    throw redirect(`/refresh-session?${makeRedirectToFromHere(request)}`);
+    console.log("refresh get");
+    return refreshAuthSession(request);
   }
 
   // so, maybe we are in a POST / PUT / PATCH / DELETE method

--- a/app/core/auth/guards/require-auth-session.server.ts
+++ b/app/core/auth/guards/require-auth-session.server.ts
@@ -17,7 +17,7 @@ async function verifyAuthSession(authSession: AuthSession) {
  * Assert auth session is present and verified from supabase auth api
  *
  * If used in loader (GET method)
- * - Redirect to /refresh-session if session is expired
+ * - Refresh tokens if session is expired
  * - Return auth session if not expired
  * - Destroy session if refresh token is expired
  *
@@ -38,9 +38,8 @@ export async function requireAuthSession(
   // ok, let's challenge its access token
   const isValidSession = await verifyAuthSession(authSession);
 
-  // damn, access token expires but we can redirect. Let's go!
-  if (!isValidSession && isGet(request)) {
-    console.log("refresh get");
+  // damn, access token expires
+  if (!isValidSession) {
     return refreshAuthSession(request);
   }
 

--- a/app/core/auth/mutations/refresh-auth-session.server.ts
+++ b/app/core/auth/mutations/refresh-auth-session.server.ts
@@ -24,7 +24,6 @@ async function refreshAccessToken(refreshToken?: string) {
   return mapAuthSession(data);
 }
 
-// used in /refresh-session's loader
 export async function refreshAuthSession(
   request: Request
 ): Promise<AuthSession> {
@@ -37,14 +36,9 @@ export async function refreshAuthSession(
   // 👾 game over, log in again
   // yes, arbitrary, but it's a good way to don't let an illegal user here with an expired token
   if (!refreshedAuthSession) {
-    const currentPath = getCurrentPath(request);
-    const redirectUrl =
-      // if user access /refresh-session by typing url, don't loop
-      currentPath === "/refresh-session"
-        ? LOGIN_URL
-        : `${LOGIN_URL}?${makeRedirectToFromHere(request)}`;
+    const redirectUrl = `${LOGIN_URL}?${makeRedirectToFromHere(request)}`;
 
-    // here we throw instead of return because this function promise a UserSession and not a response object
+    // here we throw instead of return because this function promise a AuthSession and not a response object
     // https://remix.run/docs/en/v1/guides/constraints#higher-order-functions
     throw redirect(redirectUrl, {
       headers: {

--- a/app/routes/refresh-session.tsx
+++ b/app/routes/refresh-session.tsx
@@ -1,4 +1,4 @@
-import type { LoaderFunction, ActionFunction } from "@remix-run/node";
+import type { ActionFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 
 import { refreshAuthSession } from "~/core/auth/mutations";
@@ -22,6 +22,3 @@ export const action: ActionFunction = async ({ request }) => {
     }
   );
 };
-
-export const loader: LoaderFunction = async ({ request }) =>
-  refreshAuthSession(request);


### PR DESCRIPTION
Previously, when token expires, I redirected to a /refresh-session route that was just doing a call to "refreshToken" function.
Now, it's no more required, see commits

Inspired by https://sergiodxa.com/articles/working-with-refresh-tokens-in-remix