### PR TITLE
feat: add Supabase RLS demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,4 +235,20 @@ To extend your prisma schema and apply changes on your supabase database :
   npm run db:deploy-migration
   ```
 
+## Use with Supabase RLS
+
+> To test this stack with RLS, you can find a demo in [./app/routes/rls](./app/routes/rls)
+
+> **Before playing, add some RLS rules for "Note" table**
+
+| Policy name                        | Target roles  |      WITH CHECK expression |
+| ---------------------------------- | :-----------: | -------------------------: |
+| Creator can see their own notes    | authenticated | ((uid())::text = "userId") |
+| Authenticated user can add notes   | authenticated |                       true |
+| Creator can delete their own posts | authenticated | ((uid())::text = "userId") |
+
+> Then, go to [http://localhost:3000/rls/notes](http://localhost:3000/rls/notes)
+
+---
+
 CC BY-NC-SA 4.0

--- a/app/core/integrations/supabase/supabase.server.ts
+++ b/app/core/integrations/supabase/supabase.server.ts
@@ -5,6 +5,7 @@ import {
   SERVER_URL,
   SUPABASE_SERVICE_ROLE,
   SUPABASE_URL,
+  SUPABASE_ANON_PUBLIC,
 } from "~/core/utils/env.server";
 
 import type { SupabaseClient } from "./types";
@@ -22,6 +23,10 @@ if (!SUPABASE_SERVICE_ROLE) {
   throw new Error("SUPABASE_SERVICE_ROLE is not set");
 }
 
+if (!SUPABASE_ANON_PUBLIC) {
+  throw new Error("SUPABASE_ANON_PUBLIC is not set");
+}
+
 if (!SERVER_URL) throw new Error("SERVER_URL is not set");
 
 let supabaseAdmin: SupabaseClient;
@@ -29,10 +34,14 @@ let supabaseAdmin: SupabaseClient;
 // ⚠️ cloudflare needs you define fetch option : https://github.com/supabase/supabase-js#custom-fetch-implementation
 // Use Remix fetch polyfill for node (See https://remix.run/docs/en/v1/other-api/node)
 
-function getSupabaseAdmin() {
+type ClientOptions = {
+  type: "admin" | "anon";
+};
+
+function getSupabaseClient({ type }: ClientOptions = { type: "anon" }) {
   return createClient(
-    process.env.SUPABASE_URL,
-    process.env.SUPABASE_SERVICE_ROLE,
+    SUPABASE_URL,
+    type === "admin" ? SUPABASE_SERVICE_ROLE : SUPABASE_ANON_PUBLIC,
     {
       autoRefreshToken: false,
       persistSession: false,
@@ -40,17 +49,34 @@ function getSupabaseAdmin() {
   );
 }
 
+/**
+ * Provide a Supabase Client for the logged in user.
+ * It's a per request scoped client to prevent leaking access token over multiple concurrent requests and from different users.
+ */
+function supabase(accessToken: string) {
+  if (!accessToken) {
+    throw new Error(
+      "accessToken is required to provide a supabase client linked to an user"
+    );
+  }
+
+  const supabase = getSupabaseClient();
+  supabase.auth.setAuth(accessToken);
+
+  return supabase;
+}
+
 // this is needed because in development we don't want to restart
 // the server with every change, but we want to make sure we don't
 // create a new connection to Supabase with every change either.
 // in production, we'll have a single Supabase instance.
 if (NODE_ENV === "production") {
-  supabaseAdmin = getSupabaseAdmin();
+  supabaseAdmin = getSupabaseClient({ type: "admin" });
 } else {
   if (!global.__sba__) {
-    global.__sba__ = getSupabaseAdmin();
+    global.__sba__ = getSupabaseClient({ type: "admin" });
   }
   supabaseAdmin = global.__sba__;
 }
 
-export { supabaseAdmin };
+export { supabaseAdmin, supabase };

--- a/app/core/utils/env.server.ts
+++ b/app/core/utils/env.server.ts
@@ -13,6 +13,8 @@ declare global {
       SUPABASE_URL: string;
       SUPABASE_SERVICE_ROLE: string;
       SERVER_URL: string;
+      SUPABASE_ANON_PUBLIC: string;
+      SESSION_SECRET: string;
     }
   }
 }

--- a/app/routes/rls/notes.tsx
+++ b/app/routes/rls/notes.tsx
@@ -1,0 +1,74 @@
+import type { LoaderArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData, Outlet, Link, NavLink } from "@remix-run/react";
+
+import { requireAuthSession } from "~/core/auth/guards";
+import { LogoutButton } from "~/core/components";
+import { supabase } from "~/core/integrations/supabase/supabase.server";
+import { notFound } from "~/core/utils/http.server";
+
+export async function loader({ request }: LoaderArgs) {
+  const { userId, email, accessToken } = await requireAuthSession(request);
+
+  const { data: notes, error } = await supabase(accessToken)
+    .from("Note")
+    .select("id, title");
+
+  if (!notes || error) {
+    throw notFound(`No user with id ${userId}`);
+  }
+
+  return json({ email, notes });
+}
+
+export default function NotesPage() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <div className="flex h-full min-h-screen flex-col">
+      <header className="flex items-center justify-between bg-slate-800 p-4 text-white">
+        <h1 className="text-3xl font-bold">
+          <Link to=".">Notes</Link>
+        </h1>
+        <p>{data.email}</p>
+        <LogoutButton />
+      </header>
+
+      <main className="flex h-full bg-white">
+        <div className="h-full w-80 border-r bg-gray-50">
+          <Link
+            to="new"
+            className="block p-4 text-xl text-blue-500"
+          >
+            + New Note
+          </Link>
+
+          <hr />
+
+          {data.notes.length === 0 ? (
+            <p className="p-4">No notes yet</p>
+          ) : (
+            <ol>
+              {data.notes.map((note) => (
+                <li key={note.id}>
+                  <NavLink
+                    className={({ isActive }) =>
+                      `block border-b p-4 text-xl ${isActive ? "bg-white" : ""}`
+                    }
+                    to={note.id}
+                  >
+                    📝 {note.title}
+                  </NavLink>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+
+        <div className="flex-1 p-6">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/routes/rls/notes/$noteId.tsx
+++ b/app/routes/rls/notes/$noteId.tsx
@@ -1,0 +1,89 @@
+import type { ActionArgs, LoaderArgs } from "@remix-run/node";
+import { redirect, json } from "@remix-run/node";
+import { Form, useCatch, useLoaderData } from "@remix-run/react";
+import invariant from "tiny-invariant";
+
+import { requireAuthSession } from "~/core/auth/guards";
+import { commitAuthSession } from "~/core/auth/session.server";
+import { supabase } from "~/core/integrations/supabase/supabase.server";
+import { assertIsDelete } from "~/core/utils/http.server";
+
+export async function loader({ request, params }: LoaderArgs) {
+  const { accessToken } = await requireAuthSession(request);
+  invariant(params.noteId, "noteId not found");
+
+  const { data: note } = await supabase(accessToken)
+    .from("Note")
+    .select("title, body")
+    .eq("id", params.noteId)
+    .single();
+
+  if (!note) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return json({ note });
+}
+
+export async function action({ request, params }: ActionArgs) {
+  assertIsDelete(request);
+
+  const authSession = await requireAuthSession(request);
+  invariant(params.noteId, "noteId not found");
+
+  const { error } = await supabase(authSession.accessToken)
+    .from("Note")
+    .delete({ returning: "minimal" })
+    .match({ id: params.noteId });
+
+  if (error) {
+    throw json(
+      { error: "server-error-deleting-note" },
+      {
+        status: 500,
+        headers: {
+          "Set-Cookie": await commitAuthSession(request, { authSession }),
+        },
+      }
+    );
+  }
+
+  return redirect("/rls/notes", {
+    headers: {
+      "Set-Cookie": await commitAuthSession(request, { authSession }),
+    },
+  });
+}
+
+export default function NoteDetailsPage() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <h3 className="text-2xl font-bold">{data.note.title}</h3>
+      <p className="py-6">{data.note.body}</p>
+      <hr className="my-4" />
+      <Form method="delete">
+        <button
+          type="submit"
+          className="rounded bg-blue-500  py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400"
+        >
+          Delete
+        </button>
+      </Form>
+    </div>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  return <div>An unexpected error occurred: {error.message}</div>;
+}
+
+export function CatchBoundary() {
+  const caught = useCatch();
+
+  if (caught.status === 404) {
+    return <div>Note not found</div>;
+  }
+
+  throw new Error(`Unexpected caught response with status: ${caught.status}`);
+}

--- a/app/routes/rls/notes/index.tsx
+++ b/app/routes/rls/notes/index.tsx
@@ -3,13 +3,16 @@ import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 
 import { requireAuthSession } from "~/core/auth/guards";
+import { supabaseAdmin } from "~/core/integrations/supabase/supabase.server";
 // import { useWatchNotes } from "~/modules/note/hooks";
-import { getNoteCount } from "~/modules/note/queries";
 
 export async function loader({ request }: LoaderArgs) {
   await requireAuthSession(request);
 
-  const nbOfNotes = await getNoteCount();
+  // use "supabaseAdmin" to override rls for this request only, to get all notes count
+  const { count: nbOfNotes } = await supabaseAdmin
+    .from("Note")
+    .select("id", { count: "exact", head: true });
 
   return json({
     nbOfNotes,

--- a/app/routes/rls/notes/new.tsx
+++ b/app/routes/rls/notes/new.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+
+import type { LoaderArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useActionData, useTransition } from "@remix-run/react";
+import cuid from "cuid";
+import { getFormData, useFormInputProps } from "remix-params-helper";
+import { z } from "zod";
+
+import { requireAuthSession } from "~/core/auth/guards";
+import { commitAuthSession } from "~/core/auth/session.server";
+import { supabase } from "~/core/integrations/supabase/supabase.server";
+import { assertIsPost } from "~/core/utils/http.server";
+
+export const NewNoteFormSchema = z.object({
+  title: z.string().min(2, "require-title"),
+  body: z.string().min(1, "require-body"),
+});
+
+export async function action({ request }: LoaderArgs) {
+  assertIsPost(request);
+
+  const authSession = await requireAuthSession(request);
+  const formValidation = await getFormData(request, NewNoteFormSchema);
+
+  if (!formValidation.success) {
+    return json(
+      {
+        errors: {
+          title: formValidation.errors.title,
+          body: formValidation.errors.body,
+        },
+      },
+      {
+        status: 400,
+        headers: {
+          "Set-Cookie": await commitAuthSession(request, { authSession }),
+        },
+      }
+    );
+  }
+
+  const { title, body } = formValidation.data;
+
+  const { data, error } = await supabase(authSession.accessToken)
+    .from("Note")
+    .insert([
+      {
+        id: cuid(),
+        title,
+        body,
+        userId: authSession.userId,
+        updatedAt: new Date(),
+      },
+    ]);
+
+  const newNote = data?.[0];
+
+  if (!newNote || error) {
+    throw json(
+      { error: "server-error-creating-note" },
+      {
+        status: 500,
+        headers: {
+          "Set-Cookie": await commitAuthSession(request, { authSession }),
+        },
+      }
+    );
+  }
+
+  return redirect(`/rls/notes/${newNote.id}`, {
+    headers: {
+      "Set-Cookie": await commitAuthSession(request, { authSession }),
+    },
+  });
+}
+
+export default function NewNotePage() {
+  const actionData = useActionData<typeof action>();
+  const titleRef = React.useRef<HTMLInputElement>(null);
+  const bodyRef = React.useRef<HTMLTextAreaElement>(null);
+  const inputProps = useFormInputProps(NewNoteFormSchema);
+  const transition = useTransition();
+  const disabled =
+    transition.state === "submitting" || transition.state === "loading";
+
+  React.useEffect(() => {
+    if (actionData?.errors?.title) {
+      titleRef.current?.focus();
+    } else if (actionData?.errors?.body) {
+      bodyRef.current?.focus();
+    }
+  }, [actionData]);
+
+  return (
+    <Form
+      method="post"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        width: "100%",
+      }}
+    >
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Title: </span>
+          <input
+            {...inputProps("title")}
+            ref={titleRef}
+            name="title"
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+            aria-invalid={actionData?.errors?.title ? true : undefined}
+            aria-errormessage={
+              actionData?.errors?.title ? "title-error" : undefined
+            }
+            disabled={disabled}
+          />
+        </label>
+        {actionData?.errors?.title && (
+          <div
+            className="pt-1 text-red-700"
+            id="title-error"
+          >
+            {actionData.errors.title}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Body: </span>
+          <textarea
+            {...inputProps("body")}
+            ref={bodyRef}
+            name="body"
+            rows={8}
+            className="w-full flex-1 rounded-md border-2 border-blue-500 py-2 px-3 text-lg leading-6"
+            aria-invalid={actionData?.errors?.body ? true : undefined}
+            aria-errormessage={
+              actionData?.errors?.body ? "body-error" : undefined
+            }
+            disabled={disabled}
+          />
+        </label>
+        {actionData?.errors?.body && (
+          <div
+            className="pt-1 text-red-700"
+            id="body-error"
+          >
+            {actionData.errors.body}
+          </div>
+        )}
+      </div>
+
+      <div className="text-right">
+        <button
+          type="submit"
+          className="rounded bg-blue-500  py-2 px-4 text-white hover:bg-blue-600 focus:bg-blue-400"
+          disabled={disabled}
+        >
+          Save
+        </button>
+      </div>
+    </Form>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@remix-run/serve": "*",
     "@supabase/supabase-js": "^1.35.4",
     "cookie": "^0.5.0",
+    "cuid": "^2.1.8",
     "isbot": "^3.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
This PR shows Supabase RLS server side with Remix world 🚀
By design, RLS is useful for client side code when you don't have backend / API.
Since Supabase's team add [a way to link an access token to supabase client](https://supabase.com/docs/reference/javascript/auth-setauth), It opens possibilities :D 

It **can** replace all Prisma stuff if you want, but you'll have to handle your DB schema with supabase cli or manually.
Actual DB schema in this stack (made with and for Prisma) is not perfect to use only supabase sdk : I add some UID casts to match Prisma schema is RLS policies, some table column could have default value, etc...

Because this stack relies on Prisma first, I can't / don't want to remove it.

For more info : https://supabase.com/docs/guides/auth/row-level-security