### PR TITLE
feat: add providerToken mapping + enhance refresh token strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ To extend your prisma schema and apply changes on your supabase database :
 
 > Then, go to [http://localhost:3000/rls/notes](http://localhost:3000/rls/notes)
 
+## Your token expires in less than 1 hour (3600 seconds in Supabase Dashboard)
+
+If you have a lower token lifetime than me (1 hour), you should take a look at `REFRESH_THRESHOLD` in [./app/core/auth/const.ts](./app/core/auth/const.ts) and set what you think is the best value for your use case.
+
 ---
 
 CC BY-NC-SA 4.0

--- a/app/core/auth/const.ts
+++ b/app/core/auth/const.ts
@@ -2,3 +2,4 @@ export const SESSION_KEY = "authenticated";
 export const SESSION_ERROR_KEY = "error";
 export const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days;
 export const LOGIN_URL = "/login";
+export const REFRESH_THRESHOLD = 60 * 10; // 10 minutes left before token expires

--- a/app/core/auth/mutations/sign-in.server.test.ts
+++ b/app/core/auth/mutations/sign-in.server.test.ts
@@ -38,7 +38,11 @@ describe(signInWithEmail.name, () => {
     expect(fetchAuthTokenAPI.size).toEqual(1);
     const [signInRequest] = fetchAuthTokenAPI.values();
     expect(signInRequest.body).toEqual(
-      JSON.stringify({ email: USER_EMAIL, password: USER_PASSWORD })
+      JSON.stringify({
+        email: USER_EMAIL,
+        password: USER_PASSWORD,
+        gotrue_meta_security: {},
+      })
     );
   });
 });

--- a/app/core/auth/session.server.ts
+++ b/app/core/auth/session.server.ts
@@ -15,6 +15,7 @@ export interface AuthSession {
   email: string;
   expiresIn: number;
   expiresAt: number;
+  providerToken?: string | null;
 }
 
 export type RealtimeAuthSession = Pick<

--- a/app/core/auth/utils/map-auth-session.ts
+++ b/app/core/auth/utils/map-auth-session.ts
@@ -14,5 +14,6 @@ export function mapAuthSession(
     email: supabaseAuthSession.user?.email ?? "",
     expiresIn: supabaseAuthSession.expires_in ?? -1,
     expiresAt: supabaseAuthSession.expires_at ?? -1,
+    providerToken: supabaseAuthSession.provider_token,
   };
 }

--- a/app/modules/user/mutations/create-user-account.test.ts
+++ b/app/modules/user/mutations/create-user-account.test.ts
@@ -155,6 +155,7 @@ describe(createUserAccount.name, () => {
       if (matchesMethod && matchesUrl) fetchAuthAdminUserAPI.set(req.id, req);
     });
 
+    //@ts-expect-error missing vitest type
     db.user.create.mockResolvedValue(null);
 
     const result = await createUserAccount(USER_EMAIL, USER_PASSWORD);
@@ -200,6 +201,7 @@ describe(createUserAccount.name, () => {
       if (matchesMethod && matchesUrl) fetchAuthTokenAPI.set(req.id, req);
     });
 
+    //@ts-expect-error missing vitest type
     db.user.create.mockResolvedValue({ id: USER_ID, email: USER_EMAIL });
 
     const result = await createUserAccount(USER_EMAIL, USER_PASSWORD);

--- a/app/modules/user/mutations/create-user-account.test.ts
+++ b/app/modules/user/mutations/create-user-account.test.ts
@@ -113,7 +113,11 @@ describe(createUserAccount.name, () => {
     expect(fetchAuthTokenAPI.size).toEqual(1);
     const [signInRequest] = fetchAuthTokenAPI.values();
     expect(signInRequest.body).toEqual(
-      JSON.stringify({ email: USER_EMAIL, password: USER_PASSWORD })
+      JSON.stringify({
+        email: USER_EMAIL,
+        password: USER_PASSWORD,
+        gotrue_meta_security: {},
+      })
     );
     expect(fetchAuthAdminUserAPI.size).toEqual(1);
     // expect call delete auth account with the expected user id
@@ -151,7 +155,6 @@ describe(createUserAccount.name, () => {
       if (matchesMethod && matchesUrl) fetchAuthAdminUserAPI.set(req.id, req);
     });
 
-    //@ts-expect-error missing vitest type
     db.user.create.mockResolvedValue(null);
 
     const result = await createUserAccount(USER_EMAIL, USER_PASSWORD);
@@ -197,7 +200,6 @@ describe(createUserAccount.name, () => {
       if (matchesMethod && matchesUrl) fetchAuthTokenAPI.set(req.id, req);
     });
 
-    //@ts-expect-error missing vitest type
     db.user.create.mockResolvedValue({ id: USER_ID, email: USER_EMAIL });
 
     const result = await createUserAccount(USER_EMAIL, USER_PASSWORD);


### PR DESCRIPTION
Map `providerToken` : useful if you use third party auth providers
Rework refresh strategy (will refresh if token expires soon - in 10 minutes)