### PR TITLE
feat : add Supabase provider for Browser + RLS example

### DIFF
--- a/app/database/migrations/20221121205216_add_rls/migration.sql
+++ b/app/database/migrations/20221121205216_add_rls/migration.sql
@@ -1,0 +1,23 @@
+create table "rls_notes" (
+    id serial primary key,
+    user_id uuid not null references auth.users(id),
+    title text not null,
+    body text not null,
+    publish_date date not null default now()
+);
+
+alter table "rls_notes" ENABLE row level security;
+
+create POLICY "User can read their notes" on "public"."rls_notes" as PERMISSIVE for
+select to authenticated using (auth.uid() = "user_id");
+
+create POLICY "User can create notes" on "public"."rls_notes" for
+insert to authenticated with check (true);
+
+create POLICY "User can delete their notes" on "public"."rls_notes" for delete to authenticated using (auth.uid() = user_id);
+
+create POLICY "User can update their notes" on "public"."rls_notes" for
+update to authenticated using (auth.uid() = user_id);
+
+alter publication supabase_realtime
+add table "public"."rls_notes";

--- a/app/database/schema.prisma
+++ b/app/database/schema.prisma
@@ -22,5 +22,5 @@ model Note {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
-  userId    String
+  userId    String   @map("user_id")
 }

--- a/app/integrations/i18n/i18next.server.tsx
+++ b/app/integrations/i18n/i18next.server.tsx
@@ -24,6 +24,7 @@ export const i18nextServer = new RemixI18Next({
   // The backend you want to use to load the translations
   // Tip: You could pass `resources` to the `i18next` configuration and avoid
   // a backend here
+  // @ts-ignore
   backend: Backend,
 });
 

--- a/app/integrations/supabase/client.ts
+++ b/app/integrations/supabase/client.ts
@@ -7,6 +7,8 @@ import {
 } from "~/utils/env";
 import { isBrowser } from "~/utils/is-browser";
 
+import type { Database } from "./database";
+
 // ⚠️ cloudflare needs you define fetch option : https://github.com/supabase/supabase-js#custom-fetch-implementation
 // Use Remix fetch polyfill for node (See https://remix.run/docs/en/v1/other-api/node)
 function getSupabaseClient(supabaseKey: string, accessToken?: string) {
@@ -20,7 +22,9 @@ function getSupabaseClient(supabaseKey: string, accessToken?: string) {
       }
     : {};
 
-  return createClient(SUPABASE_URL, supabaseKey, {
+  // Type <Database> is only required if you fully use Supabase instead of Prisma
+  // See https://supabase.com/docs/reference/cli/usage#supabase-gen-types-typescript
+  return createClient<Database>(SUPABASE_URL, supabaseKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/app/integrations/supabase/database.ts
+++ b/app/integrations/supabase/database.ts
@@ -1,0 +1,46 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      rls_notes: {
+        Row: {
+          id: number;
+          publish_date: string | null;
+          user_id: string;
+          title: string;
+          body: string;
+        };
+        Insert: {
+          id?: number;
+          publish_date?: string | null;
+          user_id: string;
+          title: string;
+          body: string;
+        };
+        Update: {
+          id?: number;
+          publish_date?: string | null;
+          user_id?: string;
+          title: string;
+          body: string;
+        };
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+  };
+}

--- a/app/integrations/supabase/index.ts
+++ b/app/integrations/supabase/index.ts
@@ -1,2 +1,3 @@
 export * from "./client";
 export * from "./types";
+export * from "./provider";

--- a/app/integrations/supabase/provider.tsx
+++ b/app/integrations/supabase/provider.tsx
@@ -1,0 +1,154 @@
+import type { ReactElement } from "react";
+import { createContext, useContext, useState, useMemo } from "react";
+
+import { useFetcher } from "@remix-run/react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { useInterval, useMatchesData } from "~/hooks";
+import type { AuthSession } from "~/modules/auth";
+import { isBrowser } from "~/utils";
+
+import { getSupabase } from "./client";
+
+/**
+ * This is how to use Supabase in the browser
+ *
+ * In root.tsx
+ * 1 : Return the user auth session and browser env (SUPABASE_URL and SUPABASE_ANON_PUBLIC)
+ *
+ * import { getBrowserEnv } from "./utils/env";
+ *
+ * export async function loader({ request }: LoaderArgs) {
+ *  const { accessToken, expiresAt, expiresIn } = (await getAuthSession(request)) || {};
+ *
+ *  return json({
+ *    env: {
+ *      SUPABASE_ANON_PUBLIC: process.env.SUPABASE_ANON_PUBLIC,
+ *      SUPABASE_URL: process.env.SUPABASE_URL,
+ *    },
+ *    authSession: {
+ *      accessToken,
+ *      expiresAt,
+ *      expiresIn,
+ *    },
+ *  });
+ * }
+ *
+ *
+ * 2 : Inject env in <script> tag.
+ * Wrap <Outlet /> with <SupabaseProvider><Outlet /></SupabaseProvider>
+ * authSession is used elsewhere with a special Remix hook ;)
+ *
+ * export default function App() {
+ * const { env } = useLoaderData<typeof loader>();
+ *
+ * return (
+ *   <html lang="en" className="h-screen bg-neutral-50 text-gray-900">
+ *     <head>
+ *       <Meta />
+ *       <Links />
+ *     </head>
+ *     <body className="h-full">
+ *       <SupabaseProvider>
+ *         <Outlet />
+ *       </SupabaseProvider>
+ *       <ConditionalScrollRestoration />
+ *       <script
+ *         dangerouslySetInnerHTML={{
+ *           __html: `window.env = ${JSON.stringify(env)}`,
+ *         }}
+ *       />
+ *       <Scripts />
+ *       <LiveReload />
+ *     </body>
+ *   </html>
+ *  );
+ * }
+ *
+ *
+ * 3 : In the component you want to use supabase, use the hook useSupabase()
+ *
+ * export default function SubscribeToRealtime() {
+ *  const [data, setData] = useState([])
+ *  const supabase = useSupabase()
+ *
+ *  useEffect(() => {
+ *    const channel = supabase
+ *      .channel('test')
+ *      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'test' }, (payload) => {
+ *        setData((data) => [...data, payload.new])
+ *     })
+ *      .subscribe()
+ *
+ *    return () => {
+ *      supabase.removeChannel(channel)
+ *    }
+ *  }, [session])
+ *
+ *  return <pre>{JSON.stringify({ data }, null, 2)}</pre>
+ * }
+ */
+
+const SupabaseContext = createContext<SupabaseClient | undefined>(undefined);
+
+// in root.tsx, wrap <Outlet /> with <SupabaseProvider> to use supabase'browser client
+export const SupabaseProvider = ({ children }: { children: ReactElement }) => {
+  // what root loader data returns
+  const { accessToken, expiresIn, expiresAt } = useOptionalAuthSession();
+  const [currentExpiresAt, setCurrentExpiresAt] = useState<
+    number | undefined
+  >();
+  const [supabase, setSupabase] = useState<SupabaseClient | undefined>(() => {
+    // prevents server side initial state
+    // init a default anonymous client in browser until we have an auth token
+    if (isBrowser) return getSupabase();
+  });
+  const refresh = useFetcher();
+
+  // auto refresh session at expire time
+  useInterval(() => {
+    // refreshes only if expiresIn is defined
+    // prevents refresh when user is not logged in
+    if (expiresIn)
+      refresh.submit(null, {
+        method: "post",
+        action: "/refresh-session",
+      });
+  }, expiresIn);
+
+  // when in browser
+  // after root loader fetch, if user session is refresh, it's time to create a new supabase client
+  if (isBrowser && expiresAt !== currentExpiresAt) {
+    // recreate a supabase client to force provider's consumer to rerender
+    const client = getSupabase(accessToken);
+
+    // refresh provider's state
+    setCurrentExpiresAt(expiresAt);
+    setSupabase(client);
+  }
+
+  const value = useMemo(() => supabase, [supabase]);
+
+  return (
+    <SupabaseContext.Provider value={value}>
+      {children}
+    </SupabaseContext.Provider>
+  );
+};
+
+export const useSupabase = () => {
+  const context = useContext(SupabaseContext);
+
+  if (isBrowser && context === undefined) {
+    throw new Error(`useSupabase must be used within a SupabaseProvider.`);
+  }
+
+  return context;
+};
+
+// Remix feature here, we can "watch" root loader data
+function useOptionalAuthSession(): Partial<AuthSession> {
+  const data = useMatchesData<{ authSession: AuthSession }>("root");
+
+  return data?.authSession || {};
+}

--- a/app/modules/auth/const.ts
+++ b/app/modules/auth/const.ts
@@ -1,0 +1,1 @@
+export const REFRESH_ACCESS_TOKEN_THRESHOLD = 60 * 10; // 10 minutes left before token expires

--- a/app/modules/auth/index.ts
+++ b/app/modules/auth/index.ts
@@ -11,6 +11,7 @@ export {
   destroyAuthSession,
   requireAuthSession,
   getAuthSession,
+  refreshAuthSession,
 } from "./session.server";
 export * from "./types";
 export * from "./components";

--- a/app/modules/auth/mappers.ts
+++ b/app/modules/auth/mappers.ts
@@ -1,5 +1,6 @@
 import type { SupabaseAuthSession } from "~/integrations/supabase";
 
+import { REFRESH_ACCESS_TOKEN_THRESHOLD } from "./const";
 import type { AuthSession } from "./types";
 
 export function mapAuthSession(
@@ -18,7 +19,9 @@ export function mapAuthSession(
     refreshToken: supabaseAuthSession.refresh_token,
     userId: supabaseAuthSession.user.id,
     email: supabaseAuthSession.user.email,
-    expiresIn: supabaseAuthSession.expires_in ?? -1,
+    // we set a threshold to force access token refresh before it expires when we use Supabase in Browser
+    expiresIn:
+      (supabaseAuthSession.expires_in ?? 3600) - REFRESH_ACCESS_TOKEN_THRESHOLD,
     expiresAt: supabaseAuthSession.expires_at ?? -1,
   };
 }

--- a/app/modules/auth/session.server.ts
+++ b/app/modules/auth/session.server.ts
@@ -9,6 +9,7 @@ import {
   SESSION_SECRET,
 } from "~/utils";
 
+import { REFRESH_ACCESS_TOKEN_THRESHOLD } from "./const";
 import { refreshAccessToken, verifyAuthSession } from "./service.server";
 import type { AuthSession } from "./types";
 
@@ -16,7 +17,6 @@ const SESSION_KEY = "authenticated";
 const SESSION_ERROR_KEY = "error";
 const SESSION_MAX_AGE = 60 * 60 * 24 * 7; // 7 days;
 const LOGIN_URL = "/login";
-const REFRESH_ACCESS_TOKEN_THRESHOLD = 60 * 10; // 10 minutes left before token expires
 
 /**
  * Session storage CRUD

--- a/app/modules/auth/session.server.ts
+++ b/app/modules/auth/session.server.ts
@@ -164,7 +164,9 @@ function isExpiringSoon(expiresAt: number) {
   return (expiresAt - REFRESH_ACCESS_TOKEN_THRESHOLD) * 1000 < Date.now();
 }
 
-async function refreshAuthSession(request: Request): Promise<AuthSession> {
+export async function refreshAuthSession(
+  request: Request
+): Promise<AuthSession> {
   const authSession = await getAuthSession(request);
 
   const refreshedAuthSession = await refreshAccessToken(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,8 +1,4 @@
-import type {
-  LinksFunction,
-  LoaderFunction,
-  MetaFunction,
-} from "@remix-run/node";
+import type { LinksFunction, LoaderArgs, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import {
   Links,
@@ -33,7 +29,7 @@ export const meta: MetaFunction = () => ({
   viewport: "width=device-width,initial-scale=1",
 });
 
-export const loader: LoaderFunction = async ({ request }) => {
+export async function loader({ request }: LoaderArgs) {
   const [locale, authSession] = await Promise.all([
     i18nextServer.getLocale(request),
     getAuthSession(request),
@@ -50,10 +46,10 @@ export const loader: LoaderFunction = async ({ request }) => {
       expiresIn,
     },
   });
-};
+}
 
 export default function App() {
-  const { env, locale } = useLoaderData<typeof loader>();
+  const { env, locale, authSession } = useLoaderData<typeof loader>();
   const { i18n } = useTranslation();
 
   useChangeLanguage(locale);
@@ -65,7 +61,7 @@ export default function App() {
         <Links />
       </head>
       <body className="h-full">
-        <SupabaseProvider>
+        <SupabaseProvider authSession={authSession}>
           <Outlet />
         </SupabaseProvider>
         <ScrollRestoration />

--- a/app/routes/refresh-session.tsx
+++ b/app/routes/refresh-session.tsx
@@ -1,0 +1,24 @@
+import type { ActionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
+import { refreshAuthSession } from "~/modules/auth";
+import { commitAuthSession } from "~/modules/auth/session.server";
+import { assertIsPost } from "~/utils/http.server";
+
+// this is just for supabase provider refresh
+export async function action({ request }: ActionArgs) {
+  assertIsPost(request);
+
+  const authSession = await refreshAuthSession(request);
+
+  return json(
+    { success: true },
+    {
+      headers: {
+        "Set-Cookie": await commitAuthSession(request, {
+          authSession,
+        }),
+      },
+    }
+  );
+}

--- a/app/routes/rls.tsx
+++ b/app/routes/rls.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+
+import type { LoaderArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  useLoaderData,
+  Outlet,
+  Link,
+  NavLink,
+  useFetcher,
+} from "@remix-run/react";
+
+import {
+  getSupabase,
+  getSupabaseAdmin,
+  useSupabase,
+} from "~/integrations/supabase";
+import { LogoutButton, requireAuthSession } from "~/modules/auth";
+import { notFound } from "~/utils/http.server";
+
+export function action() {
+  return null;
+}
+
+export async function loader({ request }: LoaderArgs) {
+  const { userId, email, accessToken } = await requireAuthSession(request);
+
+  const [{ count: nbOfNotesOnServer }, myNotes] = await Promise.all([
+    getSupabaseAdmin().from("rls_notes").select("id", { count: "exact" }),
+    getSupabase(accessToken).from("rls_notes").select("*"),
+  ]);
+
+  const { data, error } = myNotes;
+
+  if (error) {
+    throw notFound(`No user with id ${userId}`);
+  }
+
+  return json({ email, notes: data, nbOfNotesOnServer });
+}
+
+export default function NotesPage() {
+  const data = useLoaderData<typeof loader>();
+  const { submit } = useFetcher();
+  const supabase = useSupabase();
+
+  useEffect(() => {
+    if (!supabase) return;
+
+    // This is a demo of how to use the realtime client to listen for server changes
+    // On change, we'll reload all Remix loaders
+    // More options here : https://supabase.com/docs/reference/javascript/subscribe
+    const subscription = supabase
+      .channel(`public:rls_notes`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "rls_notes",
+        },
+        () => {
+          submit(null, {
+            method: "post",
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(subscription);
+    };
+  }, [submit, supabase]);
+
+  return (
+    <div className="flex h-full min-h-screen flex-col">
+      <header className="flex items-center justify-between bg-slate-800 p-4 text-white">
+        <h1 className="text-3xl font-bold">
+          <Link to=".">Notes</Link>
+        </h1>
+        <div className="flex flex-col items-center">
+          <span>{data.email}</span>
+          <span>There is {data.nbOfNotesOnServer} notes on the server</span>
+        </div>
+
+        <LogoutButton />
+      </header>
+
+      <main className="flex h-full bg-white">
+        <div className="h-full w-80 border-r bg-gray-50">
+          <Link to="new" className="block p-4 text-xl text-blue-500">
+            + New Note
+          </Link>
+
+          <hr />
+
+          {data.notes.length === 0 ? (
+            <p className="p-4">No notes yet</p>
+          ) : (
+            <ol>
+              {data.notes.map((note) => (
+                <li key={note.id}>
+                  <NavLink
+                    className={({ isActive }) =>
+                      `block border-b p-4 text-xl ${isActive ? "bg-white" : ""}`
+                    }
+                    to={String(note.id)}
+                  >
+                    📝 {note.title}
+                  </NavLink>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+
+        <div className="flex-1 p-6">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/routes/rls/$noteId.tsx
+++ b/app/routes/rls/$noteId.tsx
@@ -1,0 +1,74 @@
+import type { ActionArgs, LoaderArgs } from "@remix-run/node";
+import { redirect, json } from "@remix-run/node";
+import { Form, useCatch, useLoaderData } from "@remix-run/react";
+
+import { getSupabase } from "~/integrations/supabase";
+import { requireAuthSession, commitAuthSession } from "~/modules/auth";
+import { assertIsDelete, getRequiredParam } from "~/utils";
+
+export async function loader({ request, params }: LoaderArgs) {
+  const { accessToken } = await requireAuthSession(request);
+
+  const id = getRequiredParam(params, "noteId");
+
+  const { data, error } = await getSupabase(accessToken)
+    .from("rls_notes")
+    .select()
+    .eq("id", id);
+
+  if (error) {
+    throw new Response("Not Found", { status: 404 });
+  }
+  return json({ note: data[0] });
+}
+
+export async function action({ request, params }: ActionArgs) {
+  assertIsDelete(request);
+  const id = getRequiredParam(params, "noteId");
+  const authSession = await requireAuthSession(request);
+
+  await getSupabase(authSession.accessToken)
+    .from("rls_notes")
+    .delete()
+    .eq("id", id);
+
+  return redirect("/rls", {
+    headers: {
+      "Set-Cookie": await commitAuthSession(request, { authSession }),
+    },
+  });
+}
+
+export default function NoteDetailsPage() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <div>
+      <h3 className="text-2xl font-bold">{data.note.title}</h3>
+      <p className="py-6">{data.note.body}</p>
+      <hr className="my-4" />
+      <Form method="delete">
+        <button
+          type="submit"
+          className="rounded bg-blue-500  py-2 px-4 text-white focus:bg-blue-400 hover:bg-blue-600"
+        >
+          Delete
+        </button>
+      </Form>
+    </div>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  return <div>An unexpected error occurred: {error.message}</div>;
+}
+
+export function CatchBoundary() {
+  const caught = useCatch();
+
+  if (caught.status === 404) {
+    return <div>Note not found</div>;
+  }
+
+  throw new Error(`Unexpected caught response with status: ${caught.status}`);
+}

--- a/app/routes/rls/$noteId.tsx
+++ b/app/routes/rls/$noteId.tsx
@@ -42,6 +42,10 @@ export async function action({ request, params }: ActionArgs) {
 export default function NoteDetailsPage() {
   const data = useLoaderData<typeof loader>();
 
+  if (!data.note) {
+    return <div>Not found</div>;
+  }
+
   return (
     <div>
       <h3 className="text-2xl font-bold">{data.note.title}</h3>

--- a/app/routes/rls/index.tsx
+++ b/app/routes/rls/index.tsx
@@ -1,0 +1,23 @@
+import type { LoaderArgs } from "@remix-run/node";
+import { Link } from "@remix-run/react";
+
+import { requireAuthSession } from "~/modules/auth";
+
+export async function loader({ request }: LoaderArgs) {
+  await requireAuthSession(request);
+
+  return null;
+}
+
+export default function NoteIndexPage() {
+  return (
+    <>
+      <p>
+        No note selected. Select a note on the left, or{" "}
+        <Link to="new" className="text-blue-500 underline">
+          create a new note.
+        </Link>
+      </p>
+    </>
+  );
+}

--- a/app/routes/rls/new.tsx
+++ b/app/routes/rls/new.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+
+import type { LoaderArgs } from "@remix-run/node";
+import { json, redirect, Response } from "@remix-run/node";
+import { Form, useTransition } from "@remix-run/react";
+import { parseFormAny, useZorm } from "react-zorm";
+import { z } from "zod";
+
+import { getSupabase } from "~/integrations/supabase";
+import { requireAuthSession, commitAuthSession } from "~/modules/auth";
+import { assertIsPost, isFormProcessing } from "~/utils";
+
+export const NewNoteFormSchema = z.object({
+  title: z.string().min(2, "require-title"),
+  body: z.string().min(1, "require-body"),
+});
+
+export async function action({ request }: LoaderArgs) {
+  assertIsPost(request);
+  const authSession = await requireAuthSession(request);
+  const formData = await request.formData();
+  const result = await NewNoteFormSchema.safeParseAsync(parseFormAny(formData));
+
+  if (!result.success) {
+    return json(
+      {
+        errors: result.error,
+      },
+      {
+        status: 400,
+        headers: {
+          "Set-Cookie": await commitAuthSession(request, { authSession }),
+        },
+      }
+    );
+  }
+
+  const { title, body } = result.data;
+
+  const { data, error } = await getSupabase(authSession.accessToken)
+    .from("rls_notes")
+    .insert({
+      body,
+      title,
+      user_id: authSession.userId,
+    })
+    .select();
+
+  if (error) {
+    throw new Response("Error creating note", { status: 500 });
+  }
+
+  return redirect(`/rls/${data[0].id}`, {
+    headers: {
+      "Set-Cookie": await commitAuthSession(request, { authSession }),
+    },
+  });
+}
+
+export default function NewNotePage() {
+  const zo = useZorm("NewQuestionWizardScreen", NewNoteFormSchema);
+  const transition = useTransition();
+  const disabled = isFormProcessing(transition.state);
+
+  return (
+    <Form
+      ref={zo.ref}
+      method="post"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        width: "100%",
+      }}
+    >
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Title: </span>
+          <input
+            name={zo.fields.title()}
+            className="flex-1 rounded-md border-2 border-blue-500 px-3 text-lg leading-loose"
+            disabled={disabled}
+          />
+        </label>
+        {zo.errors.title()?.message && (
+          <div className="pt-1 text-red-700" id="title-error">
+            {zo.errors.title()?.message}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label className="flex w-full flex-col gap-1">
+          <span>Body: </span>
+          <textarea
+            name={zo.fields.body()}
+            rows={8}
+            className="w-full flex-1 rounded-md border-2 border-blue-500 py-2 px-3 text-lg leading-6"
+            disabled={disabled}
+          />
+        </label>
+        {zo.errors.body()?.message && (
+          <div className="pt-1 text-red-700" id="body-error">
+            {zo.errors.body()?.message}
+          </div>
+        )}
+      </div>
+
+      <div className="text-right">
+        <button
+          type="submit"
+          className="rounded bg-blue-500  py-2 px-4 text-white focus:bg-blue-400 hover:bg-blue-600"
+          disabled={disabled}
+        >
+          Save
+        </button>
+      </div>
+    </Form>
+  );
+}

--- a/mocks/handlers.js
+++ b/mocks/handlers.js
@@ -6,7 +6,7 @@ const supabaseAuthSession = {
   user: { id: USER_ID, email: USER_EMAIL },
   refresh_token: "valid",
   access_token: "valid",
-  expires_in: -1,
+  expires_in: 3600,
 };
 
 const authSession = {
@@ -14,7 +14,7 @@ const authSession = {
   accessToken: "valid",
   userId: USER_ID,
   email: USER_EMAIL,
-  expiresIn: -1,
+  expiresIn: 3000,
   expiresAt: -1,
 };
 


### PR DESCRIPTION
Add Supabase Provider to use Supabase client (with RLS support) in the browser.
Add a `/rls` route example to illustrate.
Add `/refresh-session` [route](https://github.com/rphlmr/supa-fly-stack/compare/feat/add-supabase-client-provider?expand=1#diff-6a28a120bcf1ed97940a5e2c083ef83d79c4a546b3be73eb2a102341d3dacfae) to enable session refresh (triggered by the Provider on expires).
Add doc in a code comment to explain [how It works](https://github.com/rphlmr/supa-fly-stack/compare/feat/add-supabase-client-provider?expand=1#diff-2abecc77591495606dd14307b76a6b535bc645fee51db80a4c2c7f14d581f3d3).
Add a migration to create a RLS table, for demo purposes.
Add a type `Database` to have typing completion (It's only to illustrate [how it works with supabase cli](https://supabase.com/docs/reference/cli/usage#supabase-gen-types-typescript))