### PR TITLE
Fix Supabase breaking change on PASSWORD_RECOVERY

### DIFF
--- a/app/routes/reset-password.tsx
+++ b/app/routes/reset-password.tsx
@@ -110,7 +110,9 @@ export default function ResetPassword() {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event, supabaseSession) => {
-      if (event === "SIGNED_IN") {
+      // In local development, we doesn't see "PASSWORD_RECOVERY" event because:
+      // Effect run twice and break listener chain
+      if (event === "PASSWORD_RECOVERY" || event === "SIGNED_IN") {
         const refreshToken = supabaseSession?.refresh_token;
 
         if (!refreshToken) return;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "@remix-run/serve": "*",
-    "@supabase/supabase-js": "^2.8.0",
+    "@supabase/supabase-js": "^2.24.0",
     "cookie": "^0.5.0",
     "i18next": "^21.9.1",
     "i18next-browser-languagedetector": "^6.1.5",


### PR DESCRIPTION
On reset password we now have to listen to `event === "PASSWORD_RECOVERY" ` 

Ref: https://github.com/supabase/gotrue-js/pull/629