### PR TITLE
Fix typo in npm loglevel option

### DIFF
--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -89,7 +89,7 @@ async function main({ rootDirectory, packageManager }) {
 		),
 	]);
 
-	execSync("npm run format -- --loglevel warn", {
+	execSync("npm run format -- --log-level warn", {
 		stdio: "inherit",
 		cwd: rootDirectory,
 	});


### PR DESCRIPTION
I noticed this warning after running `npx create-remix --template rphlmr/supa-fly-stack`
```
> format
> prettier --write . --loglevel warn

[warn] Ignored unknown option --loglevel=warn. Did you mean --log-level?
```